### PR TITLE
usaa translator: replace \r with \n globally

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,12 +71,14 @@ func main() {
 		panic(err)
 	}
 
-	cleared := ynabReg.Clear(usaaReg)
+	err = ynabReg.Clear(usaaReg)
+	if err != nil {
+		panic(err)
+	}
 	tbl := table.NewWriter()
 	tbl.SetAutoIndex(true)
 	tbl.SetTitle("YNAB Entries Test")
 	tbl.AppendHeader(table.Row{"Date", "Payee", "Amount", "Cleared", "Sort"})
-	tbl.AppendFooter(table.Row{fmt.Sprintf("Cleared: %d", cleared)})
 
 	tbl.SortBy([]table.SortBy{{
 		Name: "Sort",


### PR DESCRIPTION
Pending transactions in USAA are terminated with CRs, where as all posted transactions end with LF.  I have no idea why.  This breaks encoding/csv as it doesn't recognize CRs and assumes all pending charges are actually one very long entry.

This fix unwraps the reader, replaces all CR bytes with LF bytes, and rewraps it in a reader prior to the CSV decoding.

fixes #4 

Signed-off-by: jcope <jcope@redhat.com>